### PR TITLE
#30 added enumeration on scrape all

### DIFF
--- a/datagorri/view/modeler/page_dom/list/element.py
+++ b/datagorri/view/modeler/page_dom/list/element.py
@@ -30,11 +30,20 @@ class Element:
         self.label_entry.grid(row=at_grid_row, column=3, sticky=tkinter.E)
         self.label_entry.bind("<Key>", lambda event: self._auto_select_scrape_checkbox(event))
     
-    def handle_scrape_all(self, select):
+    def handle_scrape_all(self, select, level, number):
+        """
+        Selects/deselects the scrape checkbutton and fills the output label
+        :param select: (boolean) True if the checkbutton will be selected, False otherwise
+        :param level: (integer) number showing the level
+        :param number: (integer) the number the output label should show
+        """
         if select:
             self.scrape_checkbutton.select()
+            level_str = str(level) + "." if level != 0 else ""
+            self.label.set(level_str + str(number))
         else:
             self.scrape_checkbutton.deselect()
+            self.label.set("")
     
     def _auto_select_scrape_checkbox(self, event):
         """

--- a/datagorri/view/modeler/page_dom/list/element.py
+++ b/datagorri/view/modeler/page_dom/list/element.py
@@ -39,11 +39,11 @@ class Element:
         """
         if select:
             self.scrape_checkbutton.select()
-            level_str = str(level) + "." if level != 0 else ""
-            self.label.set(level_str + str(number))
+            if self.get_label() == "":
+                level_str = str(level) + "." if level != 0 else ""
+                self.set_label(level_str + str(number))
         else:
             self.scrape_checkbutton.deselect()
-            self.label.set("")
     
     def _auto_select_scrape_checkbox(self, event):
         """

--- a/datagorri/view/modeler/page_dom/list/elements.py
+++ b/datagorri/view/modeler/page_dom/list/elements.py
@@ -83,12 +83,16 @@ class Elements(Component):
         self.show_content(repetitive)
         self.repetitive = repetitive
     
-    def handle_scrape_all(self, select):
+    def handle_scrape_all(self, select, level):
         """
-        Selects/Deselects all scrape checkboxes
+        Selects/Deselects all scrape checkboxes and enumerates the output labels
+        :param select: (boolean) True if the checkbutton was selected, False otherwise
+        :param level: (integer) number showing the level (count of nested lists) 
         """
+        number = 0
         for element in self.elements:
-            element.handle_scrape_all(select)
+            element.handle_scrape_all(select, level, number)
+            number += 1
             
     def find_nested_list(self, list_index, parent_element_index):
         """

--- a/datagorri/view/modeler/page_dom/list/list.py
+++ b/datagorri/view/modeler/page_dom/list/list.py
@@ -68,12 +68,19 @@ class List(Component):
             result['nestedLists'] = nested_lists
         
         return result
-                
+    
+    handled_lists = 0 # static variable to count select all clicks of lists
     def handle_scrape_all(self, select):
         """
-        Selects/Deselects all scrape checkboxes
+        Selects/Deselects all scrape checkboxes and enumerates the output labels
+        :param select: (boolean) True if the seclect checkboxes should be selected, False otherwise
         """
-        self.elements.handle_scrape_all(select)
+        self.elements.handle_scrape_all(select, List.handled_lists)
+        # update counter
+        if select:
+            List.handled_lists += 1
+        else:
+            List.handled_lists -= 1
         
     def handle_repetition_change(self, new_elems):
         """

--- a/datagorri/view/modeler/page_dom/list/list.py
+++ b/datagorri/view/modeler/page_dom/list/list.py
@@ -79,8 +79,6 @@ class List(Component):
         # update counter
         if select:
             List.handled_lists += 1
-        else:
-            List.handled_lists -= 1
         
     def handle_repetition_change(self, new_elems):
         """

--- a/datagorri/view/modeler/page_dom/table/content.py
+++ b/datagorri/view/modeler/page_dom/table/content.py
@@ -40,11 +40,20 @@ class Content:
         self.label_entry.grid(row=at_grid_row, column=3, sticky=tkinter.E)
         self.label_entry.bind("<Key>", lambda event: self._auto_select_scrape_checkbox(event)) #5 bind typing to select scrape checkbox
 
-    def handle_scrape_all(self, select):
+    def handle_scrape_all(self, select, level, number):
+        """
+        selects the scrape checkbutton and sets the output label
+        :param select: (boolean) True if the checkbutton was selected, False otherwise
+        :param level: (integer) number of previously select tables
+        :param number: (integer) the number the output label should show
+        """
         if select:
             self.scrape_checkbutton.select()
+            level_str = str(level) + "." if level != 0 else ""
+            self.label.set(level_str + str(number))
         else:
             self.scrape_checkbutton.deselect()
+            self.label.set("")
     
     def _auto_select_scrape_checkbox(self, event):
         """

--- a/datagorri/view/modeler/page_dom/table/content.py
+++ b/datagorri/view/modeler/page_dom/table/content.py
@@ -49,11 +49,11 @@ class Content:
         """
         if select:
             self.scrape_checkbutton.select()
-            level_str = str(level) + "." if level != 0 else ""
-            self.label.set(level_str + str(number))
+            if self.get_label() == "":
+                level_str = str(level) + "." if level != 0 else ""
+                self.set_label(level_str + str(number))
         else:
             self.scrape_checkbutton.deselect()
-            self.label.set("")
     
     def _auto_select_scrape_checkbox(self, event):
         """

--- a/datagorri/view/modeler/page_dom/table/contents.py
+++ b/datagorri/view/modeler/page_dom/table/contents.py
@@ -90,9 +90,16 @@ class Contents(Component):
                     empty_placeholder_frame = tkinter.Frame(col_frame, height=10)
                     empty_placeholder_frame.grid(row=at_grid_row, column=0)
 
-    def handle_scrape_all(self, select):
+    def handle_scrape_all(self, select, level):
+        """
+        selects/deselects all scrape checkbuttons and enumerates the output labels
+        :param select: (boolean) True if the checkbutton was selected, False otherwise
+        :param level: (number) number of previously selected tables
+        """
+        number = 0
         for content in self.contents:
-            content.handle_scrape_all(select)
+            content.handle_scrape_all(select, level, number)
+            number += 1
                     
     def change_repetition_style(self, repetitive):
         if self.repetitive == repetitive:  # style already in use?

--- a/datagorri/view/modeler/page_dom/table/table.py
+++ b/datagorri/view/modeler/page_dom/table/table.py
@@ -91,8 +91,6 @@ class Table(Component):
         # update counter
         if select:
             Table.handled_tables += 1
-        else:
-            Table.handled_tables -= 1
         
     def handle_repetition_change(self, new_rows):
         """

--- a/datagorri/view/modeler/page_dom/table/table.py
+++ b/datagorri/view/modeler/page_dom/table/table.py
@@ -81,11 +81,18 @@ class Table(Component):
 
         return result
 
+    handled_tables = 0 # static variable to count select all clicks of tables
     def handle_scrape_all(self, select):
         """
-        selects/deselects all scrape checkboxes
+        selects/deselects all scrape checkboxes and enumerates the output labels
+        :param select: (boolean) True if the scrape checkboxes should be selected, False otherwise
         """
-        self.content.handle_scrape_all(select)
+        self.content.handle_scrape_all(select, Table.handled_tables)
+        # update counter
+        if select:
+            Table.handled_tables += 1
+        else:
+            Table.handled_tables -= 1
         
     def handle_repetition_change(self, new_rows):
         """


### PR DESCRIPTION
I added the enumeration of the labels on scrape all. Every click increases (on select all) or decreases (on deselect all) a counter, so no duplicate label (within tables or lists) should occur. Please test the enhancement and tell me if it fulfills the request.