### PR TITLE
#32 added new data types ImgTitle and LinkTitle which contain tooltip texts

### DIFF
--- a/datagorri/controller/content_types/img.py
+++ b/datagorri/controller/content_types/img.py
@@ -40,6 +40,13 @@ class Img(ContentType):
                 'value': Img.get_src_val(tag, img_index),
                 'img_index': img_index
             })
+            if not img['title'] == '':
+                returns.append({
+                    'index': tag.get_index(),
+                    'type': Img.type + 'Title',
+                    'value': Img.get_title_val(tag, img_index),
+                    'img_index': img_index
+                })
 
         return returns
 
@@ -72,3 +79,18 @@ class Img(ContentType):
 
         img = images[img_index]
         return img['src'].strip().replace('\n', '').replace('\r', '')
+        
+    @staticmethod
+    def get_title_val(tag, img_index):
+        """
+        Returns the title / tooltip of an image or False
+        :param tag: (Column or ListElement) the column or list element
+        :param img_index: (int) the number index of the image in the column
+        :return: (string or False)
+        """
+        images = tag.get_images()
+        if len(images) - 1 < img_index:
+            return False
+            
+        img = images[img_index]
+        return img['title'].strip().replace('\n', '').replace('\r', '')

--- a/datagorri/controller/content_types/link.py
+++ b/datagorri/controller/content_types/link.py
@@ -43,6 +43,14 @@ class Link(ContentType):
                     'value': Link.get_text_val(tag, link_index),
                     'link_index': link_index
                 })
+            
+            if not link['title'] == '':
+                returns.append({
+                    'index': tag.get_index(),
+                    'type': Link.type + 'Title',
+                    'value': Link.get_title_val(tag, link_index),
+                    'link_index': link_index
+                })
 
         return returns
 
@@ -77,3 +85,18 @@ class Link(ContentType):
 
         link = links[link_index]
         return link['href'].strip().replace('\n', '').replace('\r', '')
+        
+    @staticmethod
+    def get_title_val(tag, link_index):
+        """
+        Returns the to a link corresponding title value or False if the value is not available
+        :param tag: (Column or ListElement) the column or list element
+        :param link_index: (int) position of the link
+        :return: (string or False)
+        """
+        links = tag.get_links()
+        if len(links) - 1 < link_index:
+            return False
+        
+        link = links[link_index]
+        return link['title'].strip().replace('\n', '').replace('\r', '')

--- a/datagorri/controller/scraper.py
+++ b/datagorri/controller/scraper.py
@@ -583,10 +583,14 @@ class Scraper(Controller):
             return ImgTag.get_alt_val(element, img_index)
         elif type == 'ImgSrc':
             return ImgTag.get_src_val(element, img_index)
+        elif type == 'ImgTitle':
+            return ImgTag.get_title_val(element, img_index)
         elif type == 'LinkText':
             return LinkTag.get_text_val(element, link_index)
         elif type == 'Link':
             return LinkTag.get_href_val(element, link_index)
+        elif type == 'LinkTitle':
+            return LinkTag.get_title_val(element, link_index)
 
         return False
     
@@ -621,10 +625,14 @@ class Scraper(Controller):
             return ImgTag.get_alt_val(col, img_index)
         elif type == 'ImgSrc':
             return ImgTag.get_src_val(col, img_index)
+        elif type == 'ImgTitle':
+            return ImgTag.get_title_val(col, img_index)
         elif type == 'LinkText':
             return LinkTag.get_text_val(col, link_index)
         elif type == 'Link':
             return LinkTag.get_href_val(col, link_index)
+        elif type == 'LinkTitle':
+            return LinkTag.get_title_val(col, link_index)
 
         return False
 

--- a/datagorri/model/list/listelement.py
+++ b/datagorri/model/list/listelement.py
@@ -49,7 +49,8 @@ class ListElement:
             if a.has_attr('href'):
                 links.append({
                     "href": a['href'],
-                    "text": a.getText()
+                    "text": a.getText(),
+                    "title": a['title'] if a.has_attr('title') else ''
                 })
 
         return links
@@ -64,7 +65,8 @@ class ListElement:
             if img.has_attr('src') or img.has_attr('alt'):
                 images.append({
                     "src": img['src'] if img.has_attr('src') else '',
-                    "alt": img['alt'] if img.has_attr('alt') else ''
+                    "alt": img['alt'] if img.has_attr('alt') else '',
+                    "title": img['title'] if img.has_attr('title') else ''
                 })
 
         return images

--- a/datagorri/model/table/column.py
+++ b/datagorri/model/table/column.py
@@ -49,7 +49,8 @@ class Column:
             if a.has_attr('href'):
                 links.append({
                     "href": a['href'],
-                    "text": a.getText()
+                    "text": a.getText(),
+                    "title": a['title'] if a.has_attr('title') else ''
                 })
 
         return links
@@ -64,7 +65,8 @@ class Column:
             if img.has_attr('src') or img.has_attr('alt'):
                 images.append({
                     "src": img['src'] if img.has_attr('src') else '',
-                    "alt": img['alt'] if img.has_attr('alt') else ''
+                    "alt": img['alt'] if img.has_attr('alt') else '',
+                    "title": img['title'] if img.has_attr('title') else ''
                 })
 
         return images

--- a/datagorri/view/modeler/page_dom/list/list.py
+++ b/datagorri/view/modeler/page_dom/list/list.py
@@ -43,10 +43,10 @@ class List(Component):
                     'label': element.get_label()
                 }
                 
-                if element.type == 'ImgAlt' or element.type == 'ImgSrc':
+                if element.type == 'ImgAlt' or element.type == 'ImgSrc' or element.type == 'ImgTitle':
                     scrape['img_index'] = element.img_index
 
-                if element.type == 'Link' or element.type == 'LinkText':
+                if element.type == 'Link' or element.type == 'LinkText' or element.type == 'LinkTitle':
                     scrape['link_index'] = element.link_index
 
                 to_scrape.append(scrape)

--- a/datagorri/view/modeler/page_dom/table/table.py
+++ b/datagorri/view/modeler/page_dom/table/table.py
@@ -52,10 +52,10 @@ class Table(Component):
                 if not is_repetitive:
                     scrape['row_index'] = content.row_index
 
-                if content.type == 'ImgAlt' or content.type == 'ImgSrc':
+                if content.type == 'ImgAlt' or content.type == 'ImgSrc' or content.type == 'ImgTitle':
                     scrape['img_index'] = content.img_index
 
-                if content.type == 'Link' or content.type == 'LinkText':
+                if content.type == 'Link' or content.type == 'LinkText' or content.type == 'LinkTitle':
                     scrape['link_index'] = content.link_index
 
                 to_scrape.append(scrape)


### PR DESCRIPTION
I added support to scrape the title attribute from image (<img>) and link (<a>) elements. These often contain tooltip texts.